### PR TITLE
fixed Dockerfile. add http-handlers for profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,18 @@ RUN apk add --no-cache git libc6-compat
 
 WORKDIR /app
 
+# Сначала копируем только файлы модулей
+COPY go.mod go.sum ./
+
+# Загружаем зависимости (этот слой закэшируется, если go.mod/go.sum не изменятся)
+RUN go mod download
+
+# Копируем остальные файлы
 COPY . .
 
-RUN go mod tidy && \
-    CGO_ENABLED=0 go build -o /app/subs-service /app/cmd/subs-service/main.go
-
-RUN chmod +x /app/subs-service
+# Собираем приложение
+RUN CGO_ENABLED=0 go build -o /app/subs-service /app/cmd/subs-service/main.go && \
+    chmod +x /app/subs-service
 
 EXPOSE 8080
 

--- a/router/router.go
+++ b/router/router.go
@@ -1,6 +1,9 @@
 package router
 
 import (
+	"net/http"
+	"net/http/pprof"
+
 	"github.com/Koshsky/subs-service/controllers"
 	"github.com/Koshsky/subs-service/middleware"
 	"github.com/Koshsky/subs-service/services"
@@ -10,7 +13,7 @@ import (
 
 func SetupRouter(db *sqlx.DB) *gin.Engine {
 	r := gin.New()
-	r.Use(middleware.RateLimiterMiddleware())
+	// r.Use(middleware.RateLimiterMiddleware())
 	r.Use(middleware.RequestLoggerMiddleware())
 	// r.Use(middleware.RequestBodyLoggerMiddleware()) // for debugging
 	r.Use(middleware.DatabaseLoggerMiddleware())
@@ -25,5 +28,32 @@ func SetupRouter(db *sqlx.DB) *gin.Engine {
 	r.PUT("/subscriptions/:id", controller.Update)
 	r.DELETE("/subscriptions/:id", controller.Delete)
 	r.GET("/subscriptions/total", controller.SumPrice)
+
+	// Регистрация pprof-обработчиков
+	registerPprofHandlers(r)
 	return r
+}
+
+func registerPprofHandlers(r *gin.Engine) {
+	// Группа маршрутов для pprof
+	pprofGroup := r.Group("/debug/pprof")
+	{
+		pprofGroup.GET("/", pprofHandler(pprof.Index))
+		pprofGroup.GET("/cmdline", pprofHandler(pprof.Cmdline))
+		pprofGroup.GET("/profile", pprofHandler(pprof.Profile))
+		pprofGroup.GET("/symbol", pprofHandler(pprof.Symbol))
+		pprofGroup.GET("/trace", pprofHandler(pprof.Trace))
+		// pprofGroup.GET("/heap", pprofHandler(pprof.Handler("heap").ServeHTTP))
+		// pprofGroup.GET("/goroutine", pprofHandler(pprof.Handler("goroutine").ServeHTTP))
+		// pprofGroup.GET("/threadcreate", pprofHandler(pprof.Handler("threadcreate").ServeHTTP))
+		// pprofGroup.GET("/block", pprofHandler(pprof.Handler("block").ServeHTTP))
+		// pprofGroup.GET("/mutex", pprofHandler(pprof.Handler("mutex").ServeHTTP))
+	}
+}
+
+// Вспомогательная функция для адаптации pprof-обработчиков к Gin
+func pprofHandler(h http.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h.ServeHTTP(c.Writer, c.Request)
+	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add HTTP profiling endpoints and optimize Dockerfile build process

New Features:
- Expose pprof profiling handlers under /debug/pprof in the Gin router

Enhancements:
- Temporarily disable the rate limiter middleware
- Optimize Dockerfile layers by separating dependency download from source copying

Build:
- Refactor Dockerfile to cache Go module downloads and streamline the build steps